### PR TITLE
Fix NullPointer on `invalidateScrollingChild`

### DIFF
--- a/exvpbs/src/main/java/com/imxie/exvpbs/ViewPagerBottomSheetBehavior.java
+++ b/exvpbs/src/main/java/com/imxie/exvpbs/ViewPagerBottomSheetBehavior.java
@@ -442,6 +442,9 @@ public class ViewPagerBottomSheetBehavior<V extends View> extends CoordinatorLay
     }
 
     public void invalidateScrollingChild() {
+        if (mViewRef==null) {
+            return;
+        }
         final View scrollingChild = findScrollingChild(mViewRef.get());
         mNestedScrollingChildRef = new WeakReference<>(scrollingChild);
     }


### PR DESCRIPTION
Fix `Attempt to invoke virtual method 'java.lang.Object java.lang.ref.WeakReference.get()' on a null object reference`